### PR TITLE
Update adm-zip to v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.8",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"adm-zip": "^0.5.9",
+				"adm-zip": "^0.6.0",
 				"colors": "^1.4.0",
 				"commander": "^9.4.0",
 				"haystack-core": "^3.0.12",
@@ -21,7 +21,6 @@
 				"defcodegen": "dist/index.js"
 			},
 			"devDependencies": {
-				"@types/adm-zip": "^0.5.0",
 				"@types/colors": "^1.2.4",
 				"@types/jest": "^29.4.0",
 				"@types/node": "^18.7.14",
@@ -1582,15 +1581,6 @@
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
 			"dev": true
 		},
-		"node_modules/@types/adm-zip": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
-			"integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.0",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -2184,11 +2174,12 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-			"integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=6.0"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -9715,15 +9706,6 @@
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
 			"dev": true
 		},
-		"@types/adm-zip": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
-			"integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.20.0",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -10211,9 +10193,9 @@
 			"dev": true
 		},
 		"adm-zip": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-			"integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="
 		},
 		"ajv": {
 			"version": "6.12.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"unsafe-perm": true
 	},
 	"devDependencies": {
-		"@types/adm-zip": "^0.5.0",
 		"@types/colors": "^1.2.4",
 		"@types/jest": "^29.4.0",
 		"@types/node": "^18.7.14",
@@ -70,7 +69,7 @@
 		"typescript-eslint-parser": "^22.0.0"
 	},
 	"dependencies": {
-		"adm-zip": "^0.5.9",
+		"adm-zip": "^0.6.0",
 		"colors": "^1.4.0",
 		"commander": "^9.4.0",
 		"haystack-core": "^3.0.12",


### PR DESCRIPTION
This PR updates the adm-zip package dependency from v0.5.0 to v0.6.0. If you run `npm audit` in this repo, you will see the following entry (amongst other entries as a result of the audit) for adm-zip:

```
adm-zip  <0.6.0
Severity: high
adm-zip: Crafted ZIP file triggers 4GB memory allocation - https://github.com/advisories/GHSA-xcpc-8h2w-3j85
fix available via `npm audit fix --force`
Will install adm-zip@0.6.0, which is a breaking change
node_modules/adm-zip
```

One of the changes for adm-zip v0.6.0 is that @types/adm-zip is no longer needed. I have included that change in this PR.

I have not run a thorough analysis to inspect any regressions. However, all the tests passed. I can inspect the changes in behavior from v0.5.0 to v0.6.0 to see if we will be affected by anything. 

More details on the adm-zip memory allocation issue can be found [here](https://github.com/advisories/GHSA-xcpc-8h2w-3j85). The release notes for adm-zip can be founder [here](https://github.com/cthackers/adm-zip/releases).